### PR TITLE
filling out IASSIST 2023 conference site

### DIFF
--- a/content/conferences/iassist2023/_index.md
+++ b/content/conferences/iassist2023/_index.md
@@ -16,7 +16,7 @@ type = "conferences-test"
 
 #### Philadelphia, PA, USA, May 29 - June 2, 2023
 
-**Host institution: IASSIST with representation from X universities in the area.** 
+**Host institution: IASSIST with representation from the University of Pennsylvania, Princeton University, Rutgers University, and other universities in the area.** 
 
 
 Call for Papers and Workshops.

--- a/content/conferences/iassist2023/accommodation.md
+++ b/content/conferences/iassist2023/accommodation.md
@@ -1,30 +1,21 @@
 +++
 year = "2023"
 draft = "false"
-title = "IASSIST 2023 - Conference Schedule"
+title = "IASSIST 2023 - Conference Hotel"
 location = "Philadelphia, PA, USA"
 type = "conferences-test"
 +++
 
-## Conference Hotel
+## IASSIST 2023 Conference Hotel
 
-Conference hotel is the most convenient place to stay as you will be only a few steps away from all the confenrece action. 
+The conference hotel and location of most meetings will be the [Philadelphia Marriott Old City](https://www.marriott.com/en-us/hotels/phlmo-philadelphia-marriott-old-city/overview/).
 
 ### To book
 
-Use the booking code "bestiassistever" at their online tool.
+Details on booking at the conference rate will be released when registration is available.
 
-<a class="btn btn-template-main" href="#" target="_blank" title="Opens to a new tab">Hote Booking Tool</a>
+## Other Hotels and Accomodations
 
-## Other Hotels
-
-Organisers have reserved a block of rooms from the following hotels:
-
-- Grand Plaza
-- Hillybily Inn
-- Party Palace
-- Motel by the Highway
-
-To book, contact hotels directly and quote booking code "bestiassistever".
+Further information on alternative hotels and accomodation options will be posted here when it is available.
 
 

--- a/content/conferences/iassist2023/call.md
+++ b/content/conferences/iassist2023/call.md
@@ -1,0 +1,42 @@
++++
+year = "2023"
+draft = "false"
+title = "IASSIST 2023 - Call for Submissions"
+location = "Philadelphia, PA, USA"
+type = "conferences-test"
++++
+
+## IASSIST 2023 Call for Submissions
+
+We welcome submissions for papers, presentations, panels, posters, and lightning talks. Panel proposals should be made up of speakers from multiple organizations to encourage diversity of debate. Finally, we expect to have many submissions, so we would kindly ask you to restrict submissions to one per person only.
+
+Call for Presentations
+While a variety of submission topics are desired, we encourage you to think about if and how your topic may fit into one of the following tracks:
+
+Partnerships and collaborations – What is the data culture like at your organization? What infrastructure – hardware, software, people or policies – are you leveraging, and is it enough? Who do you partner and collaborate with, both within and outside your own organization, and can we learn from these networking environments?
+
+Data management and archiving – How can we build a community of data sharing that is equitable for all? How can we learn from each other’s approaches to demonstrating trust to lay a strong foundation? Have you designed any new and useful approaches and tools that can help in this space?
+
+Data access, governance and ethics – As data practitioners we adhere to key principles of protecting human rights and high ethical standards. What principles, practices and tools have you worked on around data access, especially where there may be added risk in data publishing and use.
+
+Data documentation and reproducibility – For a data community to persist, members need to share a common data language. What new approaches are you using to design documentation to facilitate our shared understanding? What strategies or tools have you designed that will help us respond best to the current reproducibility ‘crisis’?
+
+Data literacy – A robust community includes not only experienced practitioners, but also newcomers. What innovative or successful approaches are you using around the topic of data literacy and how can we, as a community, better equip new practitioners with this important skill?
+
+Data services of the future – What are the needs of researchers and data owners in the future, and how will data services serve them? Ideas about how data services will expand and adapt to increasing and new requirements, and suggestions about entirely new data services will be welcome. How should these data services of the future be designed?
+
+Call for Workshops
+Workshops will be held on 6  June  2022. Please use the online submission form to submit your workshop proposal. Choose “Workshop” under Submission Type and make sure to fill out all of the information in the section called Workshops – Additional Information.
+
+Call for Special Interest Group and Birds of a Feather sessions
+This year we also welcome suggestions for Special Interest Group and Birds of a Feather sessions. We require a short proposal and a meeting agenda/discussion points to support these.
+
+Timeline
+Submitting Proposals – DEADLINE: 20 December 2022.
+Notification of acceptance: 1 February 2023.
+
+Submission
+Find more information about presentation formats, along with the link to the submission form, at:
+
+Submissions of Proposals
+Questions about presentation submissions may be sent to the Program Co-Chairs at programme@lists.iassistdata.org.

--- a/content/conferences/iassist2023/conference-committees.md
+++ b/content/conferences/iassist2023/conference-committees.md
@@ -1,0 +1,13 @@
++++
+year = "2023"
+draft = "false"
+title = "IASSIST 2023 - Conference Committees"
+location = "Philadelphia, PA, USA"
+type = "conferences-test"
++++
+
+## IASSIST 2023 Conference Committees
+
+The Program Committee chairs are Jonathan Bohan (Cornell), Keven Manuel (Ryerson), and Anja Perry (GESIS).
+
+The Local Arrangements Committee are Lynda Kellam (Penn), Bobray Bordelon (Princeton) and Ryan Womack (Rutgers), working with Concentra Conference Management Services.

--- a/content/conferences/iassist2023/conference-schedule.md
+++ b/content/conferences/iassist2023/conference-schedule.md
@@ -6,7 +6,9 @@ location = "Philadelphia, PA, USA"
 type = "conferences-test"
 +++
 
-## Conference schedule at a glance
+## IASSIST 2023 Conference schedule at a glance
+
+The typical conference schedule is shown in the following table.  Details on the 2023 schedule will appear in the Spring as the program is finalized.
 
 <style>
   table.schedule {
@@ -95,6 +97,9 @@ type = "conferences-test"
 
 ## Detailed schedule
 
+Forthcoming.
+
+<!---
 Monday|Tuesday|Wednesday|Thursday|Friday|
 ---|---|---|---|---|
 IASSIST Administrative Meeting|Workshops|Plenary|Plenary|Sessions|
@@ -103,3 +108,4 @@ Lunch on your own|Lunch on your own|Lunch|Lunch & IASSIST Business meeting|Lunch
 ||Workshops|Poster session|Sessions|Wrapup|
 IASSIST Administrative Meeting|Interest Group Discussions|Sessions|Sessions||
 ||Reception||Banquet||
+-->

--- a/content/conferences/iassist2023/maps.md
+++ b/content/conferences/iassist2023/maps.md
@@ -1,0 +1,14 @@
++++
+year = "2023"
+draft = "false"
+title = "IASSIST 2023 - Maps"
+location = "Philadelphia, PA, USA"
+type = "conferences-test"
++++
+
+## IASSIST 2023 Maps
+
+The conference will be centered at the [Philadelphia Marriott Old City. Click for a map.](https://www.openstreetmap.org/way/147318001#map=17/39.94617/-75.14362).
+
+Additional maps will be posted with locations of workshops, reception, and banquet when available.
+

--- a/content/conferences/iassist2023/registration.md
+++ b/content/conferences/iassist2023/registration.md
@@ -1,0 +1,12 @@
++++
+year = "2023"
+draft = "false"
+title = "IASSIST 2023 - Registration"
+location = "Philadelphia, PA, USA"
+type = "conferences-test"
++++
+
+## IASSIST 2023 Registration
+
+Details on registration will be available in Spring 2023.
+

--- a/content/conferences/iassist2023/social.md
+++ b/content/conferences/iassist2023/social.md
@@ -1,0 +1,15 @@
++++
+year = "2023"
+draft = "false"
+title = "IASSIST 2023 - Social Program"
+location = "Philadelphia, PA, USA"
+type = "conferences-test"
++++
+
+## IASSIST 2023 Social Program
+
+A reception will be held on Tuesday evening, May 30.
+
+The banquet will be held on Thursday evening, June 1.
+
+Further information will be posted as plans are finalized.

--- a/content/conferences/iassist2023/sponsors.md
+++ b/content/conferences/iassist2023/sponsors.md
@@ -1,0 +1,13 @@
++++
+year = "2023"
+draft = "false"
+title = "IASSIST 2023 - Sponsorship"
+location = "Philadelphia, PA, USA"
+type = "conferences-test"
++++
+
+## IASSIST 2023 Call for Sponsorship
+
+We are delighted to entertain sponsorship offers. Please contact us for details.
+
+

--- a/content/conferences/iassist2023/visa-travel.md
+++ b/content/conferences/iassist2023/visa-travel.md
@@ -1,0 +1,19 @@
++++
+year = "2023"
+draft = "false"
+title = "IASSIST 2023 - Visa and Travel"
+location = "Philadelphia, PA, USA"
+type = "conferences-test"
++++
+
+## IASSIST 2023 Visa and Travel
+
+### Basic information about visa requirements for traveling to the USA
+
+The information below is intended as a starting point.  Please confirm current requirements and guidelines directly as conditions may change.
+
+Consult the [Visa Wizard](https://travel.state.gov/content/travel/en/us-visas/visa-information-resources/wizard.html) for information about visa requirements specific to your situation. [Travel.state.gov](https://travel.state.gov) is the main site for official information on travel from the US Department of State.
+
+If you require a letter of invitation for the conference, please send an email to the Programme Committee with your name, institution, mailing address and other contact details.
+
+

--- a/layouts/partials/sidebar-conferences-test.html
+++ b/layouts/partials/sidebar-conferences-test.html
@@ -13,7 +13,7 @@
             </li>
 
             <li>
-                <a href="/conferences/">Call for Presentations and Workshops</a>
+                <a href="/conferences/iassist2023/call">Call for Presentations and Workshops</a>
             </li>
 			
             <li>
@@ -21,7 +21,7 @@
             </li>			
 			
             <li>
-                <a href="/conferences/#">Registration</a>
+                <a href="/conferences/iassist2023/registration">Registration</a>
             </li>				
 
             <li>
@@ -29,23 +29,23 @@
             </li>
 
 			<li>
-                <a href="#">Social Programme</a>
+                <a href="/conferences/iassist2023/social">Social Programme</a>
             </li>
 
             <li>
-                <a href="#">Visa and Travel</a>
+                <a href="/conferences/iassist2023/visa-travel">Visa and Travel</a>
             </li>
 			
             <li>
-                <a href="/conferences/conference-committees">Conference Committees</a>
+                <a href="/conferences/iassist2023/conference-committees">Conference Committees</a>
             </li>
 
             <li>
-                <a href="/conferences/#">Sponsorship options</a>
+                <a href="/conferences/iassist2023/sponsors">Sponsorship Options</a>
             </li>
 
             <li>
-                <a href="#">Maps</a>
+                <a href="/conferences/iassist2023/maps">Maps</a>
             </li>
 
             <li>


### PR DESCRIPTION
Using Tuomas' framework for IASSIST 2023 section on main website, "filled in the blanks" by creating pages for all of the topics implied by the links.